### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build
         run: bun run build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: latest
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
upgrade upload-artifact and download-artifact to v4. v3 that we are currently using is apparently deprecated (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and my pr of an unrelated change is breaking bc of this https://github.com/linode/eslint-plugin-cloud-manager/actions/runs/13399691827/job/37427283397